### PR TITLE
Fix alert trigger log parsing

### DIFF
--- a/pipelines/alert_trigger/aws_lambda_handler.py
+++ b/pipelines/alert_trigger/aws_lambda_handler.py
@@ -1,11 +1,20 @@
 import json
 
 def lambda_handler(event, context):
-    log = json.loads(event['body'])
+    # API Gateway passes the body as a JSON string. Handle both string
+    # and dict payloads for easier local testing.
+    if isinstance(event.get("body"), str):
+        log = json.loads(event["body"])
+    else:
+        log = event.get("body", {})
     print("Received log:", log)
 
     # Dummy scoring logic
-    if log.get("EventName") == "ConsoleLogin" and log.get("SourceIP") == "203.0.113.0":
+    # CloudTrail logs use 'eventName' and 'sourceIPAddress' keys
+    if (
+        log.get("eventName") == "ConsoleLogin"
+        and log.get("sourceIPAddress") == "203.0.113.0"
+    ):
         return {
             "statusCode": 200,
             "body": json.dumps({"alert": True, "reason": "Suspicious login from unknown IP"})

--- a/pipelines/alert_trigger/azure_function_trigger.py
+++ b/pipelines/alert_trigger/azure_function_trigger.py
@@ -7,7 +7,8 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         log = req.get_json()
         logging.info(f"Received log: {log}")
 
-        if log.get("EventName") == "4625":
+        # Windows security logs use 'EventID' for the numeric code
+        if str(log.get("EventID")) == "4625":
             return func.HttpResponse(json.dumps({
                 "alert": True,
                 "reason": "Failed login detected"


### PR DESCRIPTION
## Summary
- handle API Gateway body payloads better in `aws_lambda_handler`
- use correct log field names for AWS CloudTrail and Azure security events

## Testing
- `python -m py_compile $(find pipelines -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842fb704d34833096130dd4b475d048