### PR TITLE
Fix log ingestion utilities

### DIFF
--- a/pipelines/log_ingestion/send_to_azure.py
+++ b/pipelines/log_ingestion/send_to_azure.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from email.utils import formatdate
 
 # Azure Log Analytics Workspace Info (replace with your actual values)
 WORKSPACE_ID = "YOUR_WORKSPACE_ID"
@@ -20,7 +21,7 @@ def post_data(file_path):
         body = f.read()
     uri = f"https://{WORKSPACE_ID}.ods.opinsights.azure.com/api/logs?api-version=2016-04-01"
     content_type = "application/json"
-    rfc1123date = requests.utils.formatdate(timeval=None, localtime=False, usegmt=True)
+    rfc1123date = formatdate(timeval=None, localtime=False, usegmt=True)
     resource = "/api/logs"
     method = "POST"
     content_length = len(body)
@@ -36,4 +37,7 @@ def post_data(file_path):
     print(response.text)
 
 if __name__ == "__main__":
-    post_data("../../logs/azure_sample.json")
+    import os
+    current_dir = os.path.dirname(__file__)
+    log_path = os.path.join(current_dir, "..", "..", "logs", "azure_test.json")
+    post_data(log_path)

--- a/pipelines/log_ingestion/send_to_s3.py
+++ b/pipelines/log_ingestion/send_to_s3.py
@@ -1,5 +1,5 @@
 import boto3
-import json
+import os
 
 def upload_to_s3(bucket_name, file_path, s3_key):
     s3 = boto3.client("s3")
@@ -8,4 +8,6 @@ def upload_to_s3(bucket_name, file_path, s3_key):
     print(f"Uploaded {file_path} to s3://{bucket_name}/{s3_key}")
 
 if __name__ == "__main__":
-    upload_to_s3("security-lake-lab-logs", "../../logs/aws_sample.json", "logs/aws_sample.json")
+    current_dir = os.path.dirname(__file__)
+    log_path = os.path.join(current_dir, "..", "..", "logs", "aws_test.json")
+    upload_to_s3("security-lake-lab-logs", log_path, "logs/aws_test.json")


### PR DESCRIPTION
## Summary
- fix Azure log ingestion script using email.utils.formatdate
- ensure sample log paths resolve relative to script location
- fix S3 ingestion script sample log path

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check pipelines/log_ingestion/send_to_azure.py pipelines/log_ingestion/send_to_s3.py`
- `python pipelines/log_ingestion/send_to_azure.py` *(fails: Invalid base64 string)*
- `python pipelines/log_ingestion/send_to_s3.py` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_68430570401483309ea12baac0550baf